### PR TITLE
feat(deploy): Phase 1 OTA update workflow (#37)

### DIFF
--- a/.github/workflows/deploy-ota.yml
+++ b/.github/workflows/deploy-ota.yml
@@ -1,0 +1,85 @@
+name: EAS OTA Update
+
+# Over-the-air update deploys for JavaScript changes.
+# Publishes updates to Expo's hosted update service when commits land on
+# develop (preview channel) or main (production channel). Requires EXPO_TOKEN
+# secret to be configured; skips gracefully if missing.
+#
+# Phase 1 of the mobile deploy strategy — see docs/DEPLOY-STRATEGY.md.
+
+on:
+  push:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Opt into Node.js 24 for GitHub Actions runners (same as ci.yml).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  deploy:
+    name: Deploy OTA Update
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check for EXPO_TOKEN
+        id: check-secret
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "EXPO_TOKEN not configured. Skipping OTA update."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout code
+        if: steps.check-secret.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        if: steps.check-secret.outputs.skip != 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        if: steps.check-secret.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Setup Expo
+        if: steps.check-secret.outputs.skip != 'true'
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        if: steps.check-secret.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish OTA update
+        if: steps.check-secret.outputs.skip != 'true'
+        env:
+          BRANCH: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          # Use only the first line of the commit message to avoid multi-line quoting issues
+          FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          eas update \
+            --branch "$BRANCH" \
+            --message "$SHORT_SHA: $FIRST_LINE" \
+            --non-interactive
+
+      - name: Skip message
+        if: steps.check-secret.outputs.skip == 'true'
+        run: |
+          echo "::notice::OTA update skipped. Configure EXPO_TOKEN secret to enable deploys."
+          echo "::notice::See docs/DEPLOY-STRATEGY.md for setup instructions."

--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",

--- a/docs/DEPLOY-STRATEGY.md
+++ b/docs/DEPLOY-STRATEGY.md
@@ -1,0 +1,133 @@
+# Deploy Strategy — cadence-mobile
+
+> Related: [#37 CI/CD Pipeline](https://github.com/ralphgabriel04/cadence-mobile/issues/37)
+
+## Overview
+
+The mobile deploy strategy is rolled out in **three phases** to match the project timeline (pre-launch → beta → release). Earlier phases are cheap and fast; later phases require paid developer accounts and manual store reviews.
+
+| Phase | What ships | Prereqs | Sprint |
+|-------|------------|---------|--------|
+| **1** | OTA updates via `eas update` | `EXPO_TOKEN` + `eas init` | Sprint 2 ✅ |
+| **2** | Internal preview builds (TestFlight / APK) | Apple Dev Program + Google Play Console + API credentials | Sprint 10 |
+| **3** | Automated store submission on tag `v*` | Phase 2 complete + first manual store submission | Sprint 11 |
+
+---
+
+## Phase 1 — OTA updates (current)
+
+Publishes JavaScript-only updates to the Expo update service. Does **not** produce new native binaries.
+
+**What it can update:** JS/TS code, assets bundled with Metro, React components, static content.
+**What it cannot update:** Native modules, `app.json` permissions/plugins, bundle identifier, icon, splash screen.
+
+### Workflow trigger
+
+- **Push to `develop`** → publishes to the `preview` branch on Expo → delivered to builds on the `preview` channel
+- **Push to `main`** → publishes to the `production` branch on Expo → delivered to builds on the `production` channel
+
+See `.github/workflows/deploy-ota.yml`.
+
+### Configuration
+
+- `app.json` — `expo.runtimeVersion.policy = "appVersion"` ensures the update is only served to builds with the same native app version
+- `eas.json` — `build.preview.channel = "preview"` and `build.production.channel = "production"` map build profiles to channels
+
+### One-time setup (manual, solo dev)
+
+1. Create Expo account → https://expo.dev/signup
+2. `pnpm dlx eas-cli@latest login` (locally)
+3. `pnpm dlx eas-cli@latest init` → injects `expo.extra.eas.projectId` into `app.json`, commit the change
+4. `pnpm dlx eas-cli@latest update:configure` → wires up the update service URL
+5. Create a token at https://expo.dev/accounts/{account}/settings/access-tokens
+6. Add it to GitHub: Settings → Secrets and variables → Actions → new secret `EXPO_TOKEN`
+7. Push a commit to `develop` — the `EAS OTA Update` workflow should run and publish
+
+Until step 6 is done, the workflow skips gracefully with a `::notice::` warning instead of failing.
+
+### How testers receive updates
+
+An OTA update only reaches devices that already have a native build of the app. For Phase 1 the intended consumers are:
+
+- **Dev client builds** you have installed locally via Expo Go / dev-client APK
+- **Preview / production builds** once Phases 2-3 land
+
+There are **no end-users yet** in Phase 1 — it's purely a dev convenience.
+
+---
+
+## Phase 2 — Internal preview builds (Sprint 10)
+
+Builds real `.ipa` (iOS) and `.apk` (Android) artifacts via `eas build --profile preview` and distributes them to internal testers.
+
+### What unblocks this phase
+
+| Prereq | Cost | Time |
+|--------|------|------|
+| Apple Developer Program enrollment | $99 USD/year | 1-2 business days (verification) |
+| App Store Connect app record created | included | 15 min |
+| TestFlight internal testing setup | included | 15 min |
+| Google Play Console account | $25 USD one-time | 2-3 business days (verification) |
+| Google Play internal testing track | included | 15 min |
+| Apple Team ID + App Store Connect API key | included | 10 min |
+
+### Workflow addition
+
+New `.github/workflows/build-preview.yml` triggered on:
+
+- Manual dispatch (`workflow_dispatch`)
+- Push of a tag matching `v*-rc.*` (release candidate tags)
+
+The workflow runs `eas build --profile preview --platform all --non-interactive`. Output: build artifacts uploaded to Expo, TestFlight (iOS), and downloadable APK (Android).
+
+### Acceptance criteria for Phase 2
+
+- [ ] Apple Dev Program active + app record exists in App Store Connect
+- [ ] Google Play Console active + internal testing track configured
+- [ ] ASC API key stored as GH secret `ASC_API_KEY_BASE64` + `ASC_API_KEY_ID` + `ASC_API_ISSUER_ID`
+- [ ] Google Play service account JSON stored as GH secret `GOOGLE_SERVICE_ACCOUNT_JSON`
+- [ ] Tag `v0.1.0-rc.1` triggers a successful preview build on both platforms
+- [ ] Internal testers receive TestFlight invite within 1 hour of build completion
+
+---
+
+## Phase 3 — Automated store submission (Sprint 11)
+
+Adds `eas submit` after `eas build` on release tags to push new versions to the App Store and Google Play automatically.
+
+### Prerequisites beyond Phase 2
+
+- [ ] At least **one successful manual store submission** has been completed (Apple requires human review on first submission, Google requires data safety / content rating forms to be filled out interactively)
+- [ ] App listing metadata, screenshots, privacy policy, and review notes are complete on both stores
+- [ ] `eas.json` `submit.production` block populated with ASC app info and Play track
+
+### Workflow addition
+
+New `.github/workflows/release.yml` triggered on:
+
+- Push of a tag matching `v*` (excluding `v*-rc.*`)
+
+Runs `eas build --profile production --platform all --auto-submit --non-interactive`. Output: new version uploaded to App Store Connect (pending Apple review) and Google Play (internal → closed → production progression configured in Play Console).
+
+### Acceptance criteria for Phase 3
+
+- [ ] First manual submission (`eas build --profile production` + `eas submit --profile production`) completed successfully on both stores
+- [ ] Tagging `v1.0.0` triggers build + submit end-to-end
+- [ ] Release notes sourced from `CHANGELOG.md` or `git log v0.x..HEAD` automatically
+- [ ] `autoIncrement` in `eas.json` production profile handles build numbers
+
+---
+
+## FAQ
+
+**Q: Why not use `eas update --auto`?**
+We map `main` → `production` channel and `develop` → `preview` channel explicitly, so the branch name in Expo matches the channel name on the build. `--auto` would use the git branch name `main`, which wouldn't match the `production` channel without an extra mapping in the Expo dashboard.
+
+**Q: What happens if someone force-pushes to `main`?**
+Force push is blocked by the `protect-main-develop` ruleset on the repo. The OTA workflow still runs on any push that lands on the branch, so rollbacks happen by pushing a revert commit — **not** by force push.
+
+**Q: Can a broken update brick user devices?**
+No. Expo's update mechanism is atomic: a failed update falls back to the last known-good embedded bundle. You can also roll back on the Expo dashboard by pointing the channel at a prior update.
+
+**Q: Why not publish on PR merge instead of push?**
+PR merges ARE pushes on the target branch. The `push` trigger covers both direct commits and merge commits — the ruleset ensures only PR merges can land.

--- a/eas.json
+++ b/eas.json
@@ -13,12 +13,14 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "android": {
         "buildType": "apk"
       }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "channel": "production"
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-ota.yml` — publishes OTA updates via `eas update` on push to `develop` (preview channel) and `main` (production channel)
- Workflow skips gracefully when `EXPO_TOKEN` secret is missing — no red check, just a `::notice::` warning
- Adds `app.json` `runtimeVersion.policy = "appVersion"` so updates only reach compatible native builds
- Wires `eas.json` preview/production profiles to matching channels
- Documents the full 3-phase deploy strategy in `docs/DEPLOY-STRATEGY.md`

## Scope

This is **Phase 1 only** — JavaScript-only OTA updates. Phase 2 (native builds + TestFlight/APK distribution) and Phase 3 (automated store submission) are tracked as follow-up tickets for Sprints 10 and 11.

## Before merging

- [ ] Review `docs/DEPLOY-STRATEGY.md` phases 2-3 and confirm they match the plan
- [ ] Accept that the workflow will skip until `EXPO_TOKEN` + `eas init` are done (intentional)

## After merging — one-time manual setup (solo dev)

1. `pnpm dlx eas-cli@latest login`
2. `pnpm dlx eas-cli@latest init` — commit the resulting `projectId` in `app.json`
3. `pnpm dlx eas-cli@latest update:configure`
4. Create access token at expo.dev/settings/access-tokens
5. Add `EXPO_TOKEN` in Settings → Secrets → Actions
6. Next push to `develop` triggers the first OTA update

## Test plan

- [x] YAML lint OK (workflow matches `eas-preview.yml` pattern)
- [x] `app.json` JSON valid
- [x] `eas.json` JSON valid
- [ ] CI green on this PR (4 required checks: Lint, Type Check, Test, Build + Security Lint)
- [ ] After merge, `EAS OTA Update` workflow runs on develop and skips gracefully (no token yet)

Closes part of #37 (Phase 1 acceptance criterion: "Merge main → deploy").