### PR TITLE
chore: owner Expo vers org dopman-1 (acces equipe)

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,7 +42,7 @@
         "projectId": "efe57938-74dd-4c05-8cbc-56bab0b6da96"
       }
     },
-    "owner": "dopman",
+    "owner": "dopman-1",
     "updates": {
       "url": "https://u.expo.dev/efe57938-74dd-4c05-8cbc-56bab0b6da96"
     }


### PR DESCRIPTION
Change owner dans app.json de dopman vers org dopman-1 pour que Ralph (Owner) et Alexandre/aboisvert15 (Admin) puissent lancer le projet. Etape manuelle expo.dev: le projet projectId efe57938 doit appartenir a dopman-1 (Transfer project si encore sous dopman).