### PR TITLE
chore: retirer owner/updates Expo (dev local sans login)

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,10 +41,6 @@
       "eas": {
         "projectId": "efe57938-74dd-4c05-8cbc-56bab0b6da96"
       }
-    },
-    "owner": "dopman-1",
-    "updates": {
-      "url": "https://u.expo.dev/efe57938-74dd-4c05-8cbc-56bab0b6da96"
     }
   }
 }


### PR DESCRIPTION
Retire owner et updates de app.json pour permettre npx expo start dans Expo Go sans connexion a un compte Expo. Champs EAS uniquement utiles pour Build/Update, pas pour le dev local. projectId conserve dans extra.eas.