### PR TITLE
[Starter L1] Créer le modèle de vue et les fixtures de l'écran Aujourd'hui

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-typescript": "^7.28.5",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
+    "@types/node": "^22.10.2",
     "@types/react": "~19.1.0",
     "@typescript-eslint/eslint-plugin": "^8.58.1",
     "@typescript-eslint/parser": "^8.58.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(a0d9eea63d969d1fe864ce2d3bcc049a)
+        version: 6.0.23(5d0a2fc3ae36cff0a37327f648e63a3a)
       expo-secure-store:
         specifier: ^15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -62,10 +62,13 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@30.3.0(@types/node@25.5.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.2.5(react@19.1.0))(react@19.1.0)
+        version: 13.3.3(jest@30.3.0(@types/node@22.20.1))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.2.5(react@19.1.0))(react@19.1.0)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.20.1
       '@types/react':
         specifier: ~19.1.0
         version: 19.1.17
@@ -92,10 +95,10 @@ importers:
         version: 3.0.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@22.20.1)
       jest-expo:
         specifier: ^55.0.15
-        version: 55.0.15(@babel/core@7.29.0)(expo@54.0.33)(jest@30.3.0(@types/node@25.5.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+        version: 55.0.15(@babel/core@7.29.0)(expo@54.0.33)(jest@30.3.0(@types/node@22.20.1))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       prettier:
         specifier: ^3.8.2
         version: 3.8.2
@@ -1675,6 +1678,9 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -1757,6 +1763,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1797,41 +1804,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1864,6 +1879,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -3790,48 +3806,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.27.0:
     resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.27.0:
     resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
@@ -5177,6 +5201,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -5262,6 +5289,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -6475,7 +6503,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0
     optionalDependencies:
-      expo-router: 6.0.23(a0d9eea63d969d1fe864ce2d3bcc049a)
+      expo-router: 6.0.23(5d0a2fc3ae36cff0a37327f648e63a3a)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -7489,7 +7517,9 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.81.5': {}
 
@@ -7623,7 +7653,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@testing-library/react-native@13.3.3(jest@30.3.0(@types/node@25.5.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.2.5(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react-native@13.3.3(jest@30.3.0(@types/node@22.20.1))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.2.5(react@19.1.0))(react@19.1.0)':
     dependencies:
       jest-matcher-utils: 30.3.0
       picocolors: 1.1.1
@@ -7633,7 +7663,7 @@ snapshots:
       react-test-renderer: 19.2.5(react@19.1.0)
       redent: 3.0.0
     optionalDependencies:
-      jest: 30.3.0(@types/node@25.5.0)
+      jest: 30.3.0(@types/node@22.20.1)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -7693,6 +7723,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@25.5.0':
     dependencies:
@@ -9059,7 +9093,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-router@6.0.23(a0d9eea63d969d1fe864ce2d3bcc049a):
+  expo-router@6.0.23(5d0a2fc3ae36cff0a37327f648e63a3a):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -9092,7 +9126,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       vaul: 1.1.2(@types/react@19.1.17)(react-dom@19.2.4(react@19.1.0))(react@19.1.0)
     optionalDependencies:
-      '@testing-library/react-native': 13.3.3(jest@30.3.0(@types/node@25.5.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.2.5(react@19.1.0))(react@19.1.0)
+      '@testing-library/react-native': 13.3.3(jest@30.3.0(@types/node@22.20.1))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.2.5(react@19.1.0))(react@19.1.0)
       react-dom: 19.2.4(react@19.1.0)
       react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
@@ -9754,7 +9788,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.5.0):
+  jest-cli@30.3.0(@types/node@22.20.1):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/test-result': 30.3.0
@@ -9762,7 +9796,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)
+      jest-config: 30.3.0(@types/node@22.20.1)
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -9772,6 +9806,37 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+
+  jest-config@30.3.0(@types/node@22.20.1):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.20.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@30.3.0(@types/node@25.5.0):
     dependencies:
@@ -9864,7 +9929,7 @@ snapshots:
       jest-util: 30.3.0
       jest-validate: 30.3.0
 
-  jest-expo@55.0.15(@babel/core@7.29.0)(expo@54.0.33)(jest@30.3.0(@types/node@25.5.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+  jest-expo@55.0.15(@babel/core@7.29.0)(expo@54.0.33)(jest@30.3.0(@types/node@22.20.1))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
       '@expo/config': 55.0.14(typescript@5.9.3)
       '@expo/json-file': 10.0.13
@@ -9875,7 +9940,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@30.3.0(@types/node@25.5.0))
+      jest-watch-typeahead: 2.2.1(jest@30.3.0(@types/node@22.20.1))
       json5: 2.2.3
       lodash: 4.18.1
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
@@ -10153,11 +10218,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@30.3.0(@types/node@25.5.0)):
+  jest-watch-typeahead@2.2.1(jest@30.3.0(@types/node@22.20.1)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 30.3.0(@types/node@25.5.0)
+      jest: 30.3.0(@types/node@22.20.1)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -10201,12 +10266,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.5.0):
+  jest@30.3.0(@types/node@22.20.1):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
+      jest-cli: 30.3.0(@types/node@22.20.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12031,6 +12096,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 

--- a/src/features/today/__tests__/fixtures.test.ts
+++ b/src/features/today/__tests__/fixtures.test.ts
@@ -1,0 +1,59 @@
+import { emptyFixture, errorFixture, readyFixture } from "../fixtures";
+import type { TodayWorkout } from "../types";
+
+describe("today fixtures", () => {
+  it("ready: carries exactly 7 days of weekly compliance, one marked as today", () => {
+    expect(readyFixture.status).toBe("ready");
+    if (readyFixture.status !== "ready") return;
+
+    expect(readyFixture.weeklyCompliance).toHaveLength(7);
+
+    const todays = readyFixture.weeklyCompliance.filter((day) => day.isToday);
+    expect(todays).toHaveLength(1);
+    expect(todays[0]?.date).toBe(readyFixture.localDate);
+  });
+
+  it("ready: today's workout has an assigned coach, but the field allows null", () => {
+    expect(readyFixture.status).toBe("ready");
+    if (readyFixture.status !== "ready") return;
+
+    expect(readyFixture.todayWorkout?.coachName).toBe("Coach Véronique");
+
+    // Coaching is optional (issue: "coach facultatif") — a workout without a
+    // coach must still type-check and be a valid TodayWorkout.
+    const soloWorkout: TodayWorkout = {
+      id: "wk-solo",
+      title: "Course libre",
+      exerciseCount: 1,
+      estimatedDurationMinutes: 40,
+      coachName: null,
+      state: "scheduled",
+    };
+    expect(soloWorkout.coachName).toBeNull();
+  });
+
+  it("ready: 0 to 3 personal records", () => {
+    expect(readyFixture.status).toBe("ready");
+    if (readyFixture.status !== "ready") return;
+
+    expect(readyFixture.personalRecords.length).toBeGreaterThanOrEqual(0);
+    expect(readyFixture.personalRecords.length).toBeLessThanOrEqual(3);
+  });
+
+  it("empty: carries no data beyond its status", () => {
+    expect(emptyFixture).toEqual({ status: "empty" });
+  });
+
+  it("error: carries a human-readable message", () => {
+    expect(errorFixture.status).toBe("error");
+    if (errorFixture.status !== "error") return;
+
+    expect(typeof errorFixture.message).toBe("string");
+    expect(errorFixture.message.length).toBeGreaterThan(0);
+  });
+
+  it("covers all three real states with distinct status values", () => {
+    const statuses = [readyFixture.status, emptyFixture.status, errorFixture.status];
+    expect(new Set(statuses).size).toBe(3);
+  });
+});

--- a/src/features/today/fixtures.ts
+++ b/src/features/today/fixtures.ts
@@ -1,0 +1,46 @@
+/**
+ * Deterministic fixtures for the "Today" screen's three real states.
+ * Display text is French-Québécois; identifiers and dates are fixed so
+ * snapshots and assertions never drift between test runs.
+ */
+
+import type { TodayViewState } from "./types";
+
+export const readyFixture: TodayViewState = {
+  status: "ready",
+  localDate: "2026-08-11",
+  athlete: { displayName: "Alexandre Tremblay" },
+  todayWorkout: {
+    id: "wk-2026-08-11",
+    title: "Fractionné 6x800m",
+    exerciseCount: 6,
+    estimatedDurationMinutes: 55,
+    coachName: "Coach Véronique",
+    state: "scheduled",
+  },
+  weeklyCompliance: [
+    { date: "2026-08-05", isToday: false, status: "completed" },
+    { date: "2026-08-06", isToday: false, status: "completed" },
+    { date: "2026-08-07", isToday: false, status: "missed" },
+    { date: "2026-08-08", isToday: false, status: "completed" },
+    { date: "2026-08-09", isToday: false, status: "planned" },
+    { date: "2026-08-10", isToday: false, status: "completed" },
+    { date: "2026-08-11", isToday: true, status: "planned" },
+  ],
+  lastSession: {
+    id: "wk-2026-08-10",
+    title: "Sortie longue 14 km",
+    completedAt: "2026-08-10T09:32:00-04:00",
+  },
+  personalRecords: [
+    { id: "pr-5k", label: "5 km", value: "19:42", achievedAt: "2026-07-28" },
+    { id: "pr-10k", label: "10 km", value: "41:15", achievedAt: "2026-06-14" },
+  ],
+};
+
+export const emptyFixture: TodayViewState = { status: "empty" };
+
+export const errorFixture: TodayViewState = {
+  status: "error",
+  message: "Impossible de charger les données d'aujourd'hui. Réessaie plus tard.",
+};

--- a/src/features/today/types.ts
+++ b/src/features/today/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Local, strictly-typed data contract for the athlete's "Today" screen.
+ * Built before the Supabase service exists so UI work can start in parallel
+ * (issue #101, split of #85/#24). No React, no Supabase dependency here.
+ */
+
+/** Lifecycle of the workout scheduled for today. */
+export type TodayWorkoutState = "scheduled" | "completed" | "missed";
+
+/** Compliance status for a single day in the weekly strip. */
+export type ComplianceDayStatus = "completed" | "planned" | "missed";
+
+export interface AthleteIdentity {
+  displayName: string;
+}
+
+export interface TodayWorkout {
+  id: string;
+  title: string;
+  exerciseCount: number;
+  estimatedDurationMinutes: number;
+  /** Optional: the athlete may train without an assigned coach. */
+  coachName: string | null;
+  state: TodayWorkoutState;
+}
+
+export interface ComplianceDay {
+  /** ISO date (YYYY-MM-DD) for this day of the week. */
+  date: string;
+  isToday: boolean;
+  status: ComplianceDayStatus;
+}
+
+export interface LastSession {
+  id: string;
+  title: string;
+  /** ISO datetime the session was completed. */
+  completedAt: string;
+}
+
+export interface PersonalRecord {
+  id: string;
+  label: string;
+  value: string;
+  /** ISO date the record was achieved. */
+  achievedAt: string;
+}
+
+export interface TodayReadyData {
+  readonly status: "ready";
+  /** The athlete's local date (YYYY-MM-DD) — not the server's. */
+  localDate: string;
+  athlete: AthleteIdentity;
+  /** null when nothing is scheduled today (still a "ready" screen, not "empty"). */
+  todayWorkout: TodayWorkout | null;
+  /** Always exactly 7 entries, one per day of the current week. */
+  weeklyCompliance: ComplianceDay[];
+  lastSession: LastSession | null;
+  /** 0 to 3 recent personal records to surface. */
+  personalRecords: PersonalRecord[];
+}
+
+/**
+ * Screen-level state machine. "empty" means there is nothing to show at all
+ * (e.g. a brand-new athlete profile) — distinct from a "ready" screen whose
+ * `todayWorkout` happens to be null for today specifically.
+ */
+export type TodayViewState =
+  | { readonly status: "loading" }
+  | TodayReadyData
+  | { readonly status: "empty" }
+  | { readonly status: "error"; readonly message: string };


### PR DESCRIPTION
## Résumé
Découpe de #85 et #24. Prépare le développement UI en parallèle sans dépendre de Supabase : un contrat de données local, strictement typé, plus des fixtures réalistes pour les trois états réels de l'écran.

- `src/features/today/types.ts` : union discriminée `TodayViewState` (`loading | ready | empty | error`) plutôt qu'un objet unique truffé de champs nullables. Couvre identité d'affichage, séance du jour (coach optionnel), compliance hebdomadaire (7 jours), dernière séance, et 0 à 3 records personnels. Zéro `any`, zéro dépendance React/Supabase.
- `src/features/today/fixtures.ts` : `readyFixture`, `emptyFixture`, `errorFixture`. Identifiants et dates ISO fixes (déterministes), aucun `Date.now()`/`Math.random()`. Textes en français québécois, noms TypeScript en anglais.
- `src/features/today/__tests__/fixtures.test.ts` : vérifie les 7 jours de compliance (dont exactement un marqué « aujourd'hui »), qu'un `TodayWorkout` sans coach type-check et se construit correctement, les 0-3 records personnels, et les trois états réels distincts.

N'a touché ni `today-screen.tsx`, ni Supabase, ni les composants UI, selon le périmètre de l'issue.

**Note** : cette branche part de #107 (correctif `@types/node`, pas encore fusionné) pour avoir un `pnpm type-check` propre — le diff affiché ici se limitera automatiquement aux fichiers `today/` une fois #107 fusionnée dans `develop`.

Closes #101

## Plan de test
- [x] `pnpm type-check` → code 0
- [x] `pnpm lint` → code 0
- [x] `npx jest --runInBand` → 19/19 tests verts
- [x] Aucun `any` ajouté, aucune donnée personnelle réelle, aucun appel réseau